### PR TITLE
Fixed missing "new" flag in Usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm install --save ethjs-signer
 ```js
 const HttpProvider = require('ethjs-provider-http');
 const Eth = require('ethjs-query');
-const eth = new Eth(HttpProvider('http://localhost:8545'));
+const eth = new Eth(new HttpProvider('http://localhost:8545'));
 const sign = require('ethjs-signer').sign;
 
 const address = '0x0F6af8F8D7AAD198a7607C96fb74Ffa02C5eD86B';


### PR DESCRIPTION
Fixed missing "new" flag in usage instructions that caused an Uncaught Error: [ethjs-provider-http] the HttpProvider instance requires the "new" flag in order to function normally (e.g. `const eth = new Eth(new HttpProvider());`).

## ethjs-signer

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/ethjs/ethjs-signer/blob/master/.github/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [ ] You have followed our [**contributing guidelines**](https://github.com/ethjs/ethjs-signer/blob/master/.github/CONTRIBUTING.md)
- [ ] Pull request has tests (we are going for 100% coverage!)
- [ ] Code is well-commented, linted and follows project conventions
- [ ] Documentation is updated (if necessary)
- [ ] Internal code generators and templates are updated (if necessary)
- [ ] Description explains the issue/use-case resolved and auto-closes related issues

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/ethjs/ethjs-signer/blob/master/LICENSE.md).
